### PR TITLE
Potential fix for code scanning alert no. 1: Insecure randomness

### DIFF
--- a/apps/api-gateway/src/tcp-ingest/tcp-ingest.service.ts
+++ b/apps/api-gateway/src/tcp-ingest/tcp-ingest.service.ts
@@ -6,6 +6,7 @@
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import Redis from 'ioredis';
+import * as crypto from 'crypto';
 
 import { ClickBufferService, RedisKeys } from '@repo/redis-client';
 import { KeyType } from '@repo/shared-types';
@@ -148,7 +149,9 @@ export class TcpIngestService {
    * Generate a unique session ID
    */
   private generateSessionId(): string {
-    return `sess_${Date.now()}_${Math.random().toString(36).substring(2, 15)}`;
+    // Use cryptographically secure randomness for session identifiers
+    const randomPart = crypto.randomBytes(16).toString('hex');
+    return `sess_${randomPart}`;
   }
 
   /**


### PR DESCRIPTION
Potential fix for [https://github.com/EdouardSence/Timeless-Heroes/security/code-scanning/1](https://github.com/EdouardSence/Timeless-Heroes/security/code-scanning/1)

To fix the problem, the session ID must be generated using a cryptographically secure random source instead of `Math.random()`. In Node.js, the standard way is to use the built-in `crypto` module. A robust approach is either `crypto.randomUUID()` (simple and readable) or `crypto.randomBytes()` encoded as hex/base64. We should keep the external behavior (a string with a `sess_` prefix) while replacing the insecure randomness.

Best single fix with minimal behavioral change:

- Add an import for Node’s `crypto` module at the top of `apps/api-gateway/src/tcp-ingest/tcp-ingest.service.ts`.
- Rewrite `generateSessionId()` to use a CSPRNG:
  - Option A (Node 14.17+ / 16+): `crypto.randomUUID()` to generate a UUID v4.
  - Option B (universal): `crypto.randomBytes(16).toString('hex')` to get a 32-char hex string.
- Preserve the `sess_` prefix (and, if desired, `Date.now()` though it isn’t needed for security). To avoid leaking timing info and to simplify, we can omit the timestamp and rely purely on the random value.

Concretely:

- In `apps/api-gateway/src/tcp-ingest/tcp-ingest.service.ts`, add `import * as crypto from 'crypto';` below the existing imports.
- Change `generateSessionId()` so that:

```ts
private generateSessionId(): string {
  // Use cryptographically secure randomness for session IDs
  const randomPart = crypto.randomBytes(16).toString('hex');
  return `sess_${randomPart}`;
}
```

No other files need to be changed, and no other logic (e.g., how sessions are stored/validated) needs modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
