### PR TITLE
Potential fix for code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/apps/api/src/links/links.service.spec.ts
+++ b/apps/api/src/links/links.service.spec.ts
@@ -16,4 +16,58 @@ describe('LinksService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  describe('create (escapeHtml)', () => {
+    const createResult = (title: string | null | undefined) =>
+      service.create({ title } as any);
+
+    it('should return the title unmodified when no special characters', () => {
+      expect(createResult('My Link')).toContain("'My Link'");
+    });
+
+    it('should escape & as &amp;', () => {
+      expect(createResult('A & B')).toContain('A &amp; B');
+    });
+
+    it('should escape < as &lt;', () => {
+      expect(createResult('<script>')).toContain('&lt;script&gt;');
+    });
+
+    it('should escape > as &gt;', () => {
+      expect(createResult('a > b')).toContain('a &gt; b');
+    });
+
+    it('should escape " as &quot;', () => {
+      expect(createResult('say "hi"')).toContain('say &quot;hi&quot;');
+    });
+
+    it("should escape ' as &#39;", () => {
+      expect(createResult("it's")).toContain("it&#39;s");
+    });
+
+    it('should escape / as &#x2F;', () => {
+      expect(createResult('a/b')).toContain('a&#x2F;b');
+    });
+
+    it('should escape a combination of special characters', () => {
+      const result = createResult('<b class="x">it\'s a/b & c</b>');
+      expect(result).toContain(
+        '&lt;b class=&quot;x&quot;&gt;it&#39;s a&#x2F;b &amp; c&lt;&#x2F;b&gt;',
+      );
+    });
+
+    it('should not double-escape already-escaped sequences', () => {
+      // The function escapes "&" in "&amp;" to "&amp;amp;" since it operates on raw characters
+      const result = createResult('&amp;');
+      expect(result).toContain('&amp;amp;');
+    });
+
+    it('should return empty string when title is null', () => {
+      expect(createResult(null)).toContain("''");
+    });
+
+    it('should return empty string when title is undefined', () => {
+      expect(createResult(undefined)).toContain("''");
+    });
+  });
 });

--- a/apps/api/src/links/links.service.ts
+++ b/apps/api/src/links/links.service.ts
@@ -26,7 +26,8 @@ export class LinksService {
     },
   ];
 
-  private escapeHtml(input: string): string {
+  private escapeHtml(input: string | null | undefined): string {
+    if (input == null) return '';
     return input.replace(/[&<>"'/]/g, (char) => {
       switch (char) {
         case '&':


### PR DESCRIPTION
Potential fix for [https://github.com/EdouardSence/Timeless-Heroes/security/code-scanning/2](https://github.com/EdouardSence/Timeless-Heroes/security/code-scanning/2)

In general, to fix reflected XSS, user‑provided data should never be directly concatenated into strings that may be rendered as HTML in a client; instead, escape/encode that data or return it as structured data (e.g., JSON) and ensure proper escaping on the client. In a NestJS API, a common, safe pattern is to return an object instead of a human‑readable HTML string, or, if you must create a string that may be shown in HTML, to escape any user‑controlled fields.

For this specific code, the minimal, non‑breaking fix is to escape `createLinkDto.title` (the user‑controlled field) before interpolating it into the returned string. We can do this by introducing a small HTML‑escaping helper in `links.service.ts` and using it in `create()`. Since we’re only allowed to modify the shown snippets, we’ll implement a local `escapeHtml` function in `LinksService` instead of adding new libraries or touching other files. The function will replace the standard HTML‑special characters (`&`, `<`, `>`, `"`, `'`, and `/`) with their entity equivalents, and we’ll call it on `createLinkDto.title` when building the response string. No changes are required in `links.controller.ts`, and the existing behavior (“TODO: ... 'title'”) is preserved, except that dangerous characters in the title are now safely encoded instead of being interpreted as markup.

Concretely:
- Edit `apps/api/src/links/links.service.ts`.
- Add a private `escapeHtml` method to `LinksService`.
- Change `create()` to use ``'${this.escapeHtml(createLinkDto.title)}'`` instead of directly interpolating `createLinkDto.title`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
